### PR TITLE
Support for branches

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -11,7 +11,6 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
     def load_config(self):
         s = sublime.load_settings("Githubinator.sublime-settings")
-        global DEFAULT_GIT_BRANCH; DEFAULT_GIT_BRANCH = s.get("default_branch")
         global DEFAULT_GIT_REMOTE; DEFAULT_GIT_REMOTE = s.get("default_remote")
 
     def run(self, edit):
@@ -22,13 +21,13 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
         full_name = self.view.file_name()
         folder_name, file_name = os.path.split(full_name)
 
-        git_path = self.recurse_dir(folder_name,'.git')
+        git_path = self.recurse_dir(folder_name, '.git')
         if not git_path:
             sublime.status_message('Could not find .git directory.')
             print 'Could not find .git directory.'
             return
 
-        git_config_path = os.path.join(git_path,'.git','config')
+        git_config_path = os.path.join(git_path, '.git', 'config')
         new_git_path = folder_name[len(git_path):]
 
         with open(git_config_path, "r") as git_config_file:
@@ -49,8 +48,10 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
                 continue
             matches = result.groups()
 
+            ref_path = open(os.path.join(git_path, '.git', 'HEAD'), "r").read().replace('ref: ', '')[:-1]
+            ref = open(os.path.join(git_path, '.git', ref_path), "r").read()[:-1]
             full_link = 'https://github.com/%s/%s/blob/%s%s/%s#L%s' % \
-                (matches[0], matches[1], DEFAULT_GIT_BRANCH, new_git_path, file_name, lines)
+                (matches[0], matches[1], ref, new_git_path, file_name, lines)
             sublime.set_clipboard(full_link)
             sublime.status_message('Copied %s to clipboard.' % full_link)
             print 'Copied %s to clipboard.' % full_link


### PR DESCRIPTION
This fixes issue #7 - it uses the current `HEAD` ref rather than the default branch option.
