### PR TITLE
allow for list of default git remotes in the settings file

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -12,6 +12,8 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
     def load_config(self):
         s = sublime.load_settings("Githubinator.sublime-settings")
         global DEFAULT_GIT_REMOTE; DEFAULT_GIT_REMOTE = s.get("default_remote")
+        if not isinstance(DEFAULT_GIT_REMOTE, list):
+            DEFAULT_GIT_REMOTE = [DEFAULT_GIT_REMOTE]
 
     def run(self, edit, permalink = False, mode = 'blob'):
         self.load_config()
@@ -41,7 +43,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
         else:
             lines = '%s-%s' % (begin_line, end_line)
 
-        for remote in [DEFAULT_GIT_REMOTE]:
+        for remote in DEFAULT_GIT_REMOTE:
             regex = r'.*\s.*(?:https://github\.com/|github\.com:|git://github\.com/)(.*)/(.*?)(?:\.git)?\r?\n'
             result = re.search(remote + regex, config)
             if not result:


### PR DESCRIPTION
rather than just one.

I have some repositories where the remote is "origin", others have "upstream". By making the setting `default_remote` accept both a single string or a list of strings, I can use it for either.

It will try them in order until one matches. The basic loop for this was already there, I just fixed the setting import and made it a list if it wasn't already one (single string case).
