### PR TITLE
Allow custom hosts for GitHub Enterprise Support

### DIFF
--- a/Githubinator.sublime-settings
+++ b/Githubinator.sublime-settings
@@ -1,3 +1,4 @@
 {
-  "default_remote": "origin"
+  "default_remote": "origin",
+  "default_host": "github.com"
 }

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ The plugin should be picked up automatically. If not, restart Sublime Text.
 
 ## Configuration
 
-The defaults should work for most setups, but if you have a different remote name, you can configure it in the `Githubinator.sublime-settings` file:
+The defaults should work for most setups, but if you have a different remote name or use GitHub Enterprise, you can configure remote and host in the `Githubinator.sublime-settings` file:
 
     {
-      "default_remote": "origin"
+      "default_remote": "origin",
+      "default_host": "github.com"
     }
 
 

--- a/githubinator.py
+++ b/githubinator.py
@@ -11,9 +11,14 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
     def load_config(self):
         s = sublime.load_settings("Githubinator.sublime-settings")
-        global DEFAULT_GIT_REMOTE; DEFAULT_GIT_REMOTE = s.get("default_remote")
+        global DEFAULT_GIT_REMOTE, DEFAULT_GITHUB_HOST
+        DEFAULT_GIT_REMOTE = s.get("default_remote")
         if not isinstance(DEFAULT_GIT_REMOTE, list):
             DEFAULT_GIT_REMOTE = [DEFAULT_GIT_REMOTE]
+        DEFAULT_GITHUB_HOST = s.get("default_host")
+        if DEFAULT_GITHUB_HOST is None:
+            DEFAULT_GITHUB_HOST = "github.com"
+        
 
     def run(self, edit, permalink = False, mode = 'blob'):
         self.load_config()
@@ -43,8 +48,9 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
         else:
             lines = '%s-%s' % (begin_line, end_line)
 
+        re_host = re.escape(DEFAULT_GITHUB_HOST)
         for remote in DEFAULT_GIT_REMOTE:
-            regex = r'.*\s.*(?:https://github\.com/|github\.com:|git://github\.com/)(.*)/(.*?)(?:\.git)?\r?\n'
+            regex = r'.*\s.*(?:https://%s/|%s:|git://%s/)(.*)/(.*?)(?:\.git)?\r?\n' % (re_host, re_host, re_host)
             result = re.search(remote + regex, config)
             if not result:
                 continue
@@ -55,8 +61,8 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             sha = open(os.path.join(git_path, '.git', ref_path), "r").read()[:-1]
             target = sha if permalink else branch
 
-            full_link = 'https://github.com/%s/%s/%s/%s%s/%s#L%s' % \
-                (matches[0], matches[1], mode, target, new_git_path, file_name, lines)
+            full_link = 'https://%s/%s/%s/%s/%s%s/%s#L%s' % \
+                (DEFAULT_GITHUB_HOST, matches[0], matches[1], mode, target, new_git_path, file_name, lines)
             sublime.set_clipboard(full_link)
             sublime.status_message('Copied %s to clipboard.' % full_link)
             print('Copied %s to clipboard.' % full_link)


### PR DESCRIPTION
Just a minor tweak: I use GitHub Enterprise at my company, and wanted to be able to use GitHubinator in our internal system. This allows the domain to be custom set, which was good enough for my needs and most likely others.
