### PR TITLE
Add new branch option and context option to open githubinator on master

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,6 +1,8 @@
 [
     { "command": "githubinator", "caption": "GitHubinator", "args": { "permalink": false } },
+    { "command": "githubinator", "caption": "GitHubinator on Master", "args": { "permalink": false, "branch": "master" } },
     { "command": "githubinator", "caption": "GitHubinator Permalink", "args": { "permalink": true } },
     { "command": "githubinator", "caption": "GitHubinator Blame", "args": { "permalink": false, "mode": "blame" } },
+    { "command": "githubinator", "caption": "GitHubinator Blame on Master", "args": { "permalink": false, "mode": "blame", "branch": "master" } },
     { "command": "githubinator", "caption": "GitHubinator Blame Permalink", "args": { "permalink": true, "mode": "blame" } }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -5,6 +5,11 @@
     "args": { "permalink": false }
   },
   {
+    "caption": "GitHubinator on Master",
+    "command": "githubinator",
+    "args": { "permalink": false, "branch": "master" }
+  },
+  {
     "caption": "GitHubinator Permalink",
     "command": "githubinator",
     "args": { "permalink": true }
@@ -13,6 +18,11 @@
     "caption": "GitHubinator Blame",
     "command": "githubinator",
     "args": { "permalink": false, "mode": "blame" }
+  },
+  {
+    "caption": "GitHubinator Blame on Master",
+    "command": "githubinator",
+    "args": { "permalink": false, "mode": "blame", "branch": "master" }
   },
   {
     "caption": "GitHubinator Blame Permalink",

--- a/githubinator.py
+++ b/githubinator.py
@@ -18,9 +18,9 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
         DEFAULT_GITHUB_HOST = s.get("default_host")
         if DEFAULT_GITHUB_HOST is None:
             DEFAULT_GITHUB_HOST = "github.com"
-        
 
-    def run(self, edit, permalink = False, mode = 'blob'):
+
+    def run(self, edit, permalink = False, mode = 'blob', branch = None):
         self.load_config()
         if not self.view.file_name():
             return
@@ -57,7 +57,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             matches = result.groups()
 
             ref_path = open(os.path.join(git_path, '.git', 'HEAD'), "r").read().replace('ref: ', '')[:-1]
-            branch = ref_path.replace('refs/heads/','')
+            if branch is None: branch = ref_path.replace('refs/heads/','')
             sha = open(os.path.join(git_path, '.git', ref_path), "r").read()[:-1]
             target = sha if permalink else branch
 


### PR DESCRIPTION
Hello folks!

I've made this because of a personal need, sometimes I want to see/send the URL pointing to master instead of my current checkout'd branch.

This could obviously be a new `sublime-setting`, but I'm not sure if this is really needed, looking forward for your comments and feedbacks, even because these are my first python lines.

Also this adds a valid option for the use case described here https://github.com/ehamiter/ST2-GitHubinator/issues/24

Thanks for your attention and for the great plugin!
