### PR TITLE
Support github public and github enterprise in the same time

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -49,11 +49,14 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             lines = '%s-%s' % (begin_line, end_line)
 
         HTTP = 'https'
-        result = re.search(r'url.*?=.*?(https?)://([^/]*)/', config)
+        result = re.search(r'url.*?=.*?((https?)://([^/]*)/)|(git@([^:]*):)', config)
         if result:
             matches = result.groups()
-            HTTP = matches[0]
-            DEFAULT_GITHUB_HOST = matches[1]
+            if matches[0]:
+                HTTP = matches[1]
+                DEFAULT_GITHUB_HOST = matches[2]
+            else:
+                DEFAULT_GITHUB_HOST = matches[4]
         
         re_host = re.escape(DEFAULT_GITHUB_HOST)
         for remote in DEFAULT_GIT_REMOTE:


### PR DESCRIPTION
issue mentioned here: https://github.com/ehamiter/ST2-GitHubinator/issues/29

Two things are done here:
1. load "DEFAULT_GITHUB_HOST" from `.git/config` if find "https://" or "http://" url description
2. support "http://" style github url

PS:
My Github enterprise environment only use the https:// or http:// github style, so this PR is enough for me, but it's not robust for all Github enterprise scenarios.
