### PR TITLE
Fix TypeError for bitbucket repos

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -88,7 +88,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             lines = self.get_selected_line_nums()
 
             if 'bitbucket' in self.default_host:
-                lines = '-'.join(lines)
+                lines = '-'.join([str(l) for l in lines])
                 full_link = HTTP + '://%s/%s/%s/src/%s%s/%s?at=%s#cl-%s' % \
                     (self.default_host, username, project, sha, new_git_path,
                         file_name, branch, lines)


### PR DESCRIPTION
Currently if you are using a bitbucket remote you get a TypeError on this line - `lines` is a list of `int`s which can't be `join`ed, first they need to be turned into strings.