### PR TITLE
Bitbucket uses colon not dash to join line nos

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -88,7 +88,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             lines = self.get_selected_line_nums()
 
             if 'bitbucket' in self.default_host:
-                lines = '-'.join([str(l) for l in lines])
+                lines = ':'.join([str(l) for l in lines])
                 full_link = HTTP + '://%s/%s/%s/src/%s%s/%s?at=%s#cl-%s' % \
                     (self.default_host, username, project, sha, new_git_path,
                         file_name, branch, lines)


### PR DESCRIPTION
@ehamiter another tiny tweak for bitbucket compatibility...