### PR TITLE
Ensure a full match when looking for ref in packed-refs

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -134,8 +134,9 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
         if os.path.isfile(packed_ref_path):
             with codecs.open(packed_ref_path, "r", "utf-8") as f:
+                regex = r"\s{0}(\s.*)?$".format(ref)
                 for line in f:
-                    if ref in line:
+                    if re.search(regex, line):
                         sha = line.split(" ")[0]
 
         if not sha:


### PR DESCRIPTION
The `packed-refs` parsing added in fa936f8f44faa6426ec656c1624277d6a1f59e55 finds commit hashes based on partial matches (`ref in line`). This can have unexpected results; e.g. `refs/heads/master` would be found in a line containing `refs/heads/master-foobar`.

Since branches and therefore reference names can also contain slashes, I figured it's safest to use a regular expression match to fix the issue.