### PR TITLE
Add option to copy link on master

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -2,6 +2,7 @@
     { "command": "githubinator", "caption": "GitHubinator", "args": { "permalink": false } },
     { "command": "githubinator", "caption": "Copy GitHubinator...", "args": { "permalink": false, "copyonly": true } },
     { "command": "githubinator", "caption": "Copy GitHubinator on Master...", "args": { "permalink": false, "copyonly": true, "branch": "master" } },
+    { "command": "githubinator", "caption": "Copy GitHubinator Permalink...", "args": { "permalink": true, "copyonly": true } },
     { "command": "githubinator", "caption": "GitHubinator on Master", "args": { "permalink": false, "branch": "master" } },
     { "command": "githubinator", "caption": "GitHubinator Permalink", "args": { "permalink": true } },
     { "command": "githubinator", "caption": "GitHubinator Blame", "args": { "permalink": false, "mode": "blame" } },

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,6 +1,7 @@
 [
     { "command": "githubinator", "caption": "GitHubinator", "args": { "permalink": false } },
     { "command": "githubinator", "caption": "Copy GitHubinator...", "args": { "permalink": false, "copyonly": true } },
+    { "command": "githubinator", "caption": "Copy GitHubinator on Master...", "args": { "permalink": false, "copyonly": true, "branch": "master" } },
     { "command": "githubinator", "caption": "GitHubinator on Master", "args": { "permalink": false, "branch": "master" } },
     { "command": "githubinator", "caption": "GitHubinator Permalink", "args": { "permalink": true } },
     { "command": "githubinator", "caption": "GitHubinator Blame", "args": { "permalink": false, "mode": "blame" } },


### PR DESCRIPTION
Sometimes it's useful to copy a link to some code on the master branch, even if you're currently in another branch. Especially if you're working in a local-only branch and need to refer someone to some code.