### PR TITLE
Add Git Blame support for Bitbucket repos

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -98,9 +98,10 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             lines = self.get_selected_line_nums()
 
             if "bitbucket" in self.default_host:
+                mode = "src" if mode == "blob" else "annotate"
                 lines = ":".join([str(l) for l in lines])
-                full_link = scheme + "://%s/%s/%s/src/%s%s/%s?at=%s#cl-%s" % \
-                    (self.default_host, username, project, sha, new_git_path,
+                full_link = scheme + "://%s/%s/%s/%s/%s%s/%s?at=%s#cl-%s" % \
+                    (self.default_host, username, project, mode, sha, new_git_path,
                         file_name, branch, lines)
             else:
                 lines = "-".join("L%s" % line for line in lines)


### PR DESCRIPTION
Currently both Githubinator Blame and Permalink options both link to the same URL on Bitbucket repos. This PR should fix this by ensuring that the URL is dependent on the `mode` variable, as it is on the Github version. Bitbucket uses `.../src/...` for regular links and `.../annotate/...` for viewing blame.

Please note that I don't know any Python (I'm a JavaScript developer), so I'm not sure if this is correct. Please double-check my work!