### PR TITLE
Open .git/config with utf-8 encoding

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -53,7 +53,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
         # Read the config file in .git
         git_config_path = os.path.join(git_path, ".git", "config")
-        with open(git_config_path, "r") as git_config_file:
+        with open(git_config_path, "r", encoding="utf-8") as git_config_file:
             config = git_config_file.read()
 
         # Figure out the host

--- a/githubinator.py
+++ b/githubinator.py
@@ -53,7 +53,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
         # Read the config file in .git
         git_config_path = os.path.join(git_path, ".git", "config")
-        with open(git_config_path, "r", encoding="utf-8") as git_config_file:
+        with codecs.open(git_config_path, "r", "utf-8") as git_config_file:
             config = git_config_file.read()
 
         # Figure out the host


### PR DESCRIPTION
Hi @ehamiter 
recently GitHubinator stopped working for me because I have `user.name` config that contains letters `ą, ł` from Polish alphabet.

```
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 812, in run_
    return self.run(edit, **args)
  File "/Users/przemek/Library/Application Support/Sublime Text 3/Packages/GitHubinator/githubinator.py", line 57, in run
    config = git_config_file.read()
  File "./python3.3/encodings/ascii.py", line 26, in decode
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 613: ordinal not in range(128)
```

Wouldn't be a problem to open `.git/config` file with utf-8 encoding?
As I noticed, there is already line that is opening file like that
https://github.com/ehamiter/GitHubinator/blob/master/githubinator.py#L143

Regards,
@szemek