### PR TITLE
Mark @ as safe for username

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -112,7 +112,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
                     full_link = repo_link + "%s/%s%s/%s#%s" % \
                         (mode, target, new_git_path, file_name, lines)
 
-            full_link = quote(full_link, safe=':/#')
+            full_link = quote(full_link, safe=':/#@')
 
             sublime.set_clipboard(full_link)
             sublime.status_message("Copied %s to clipboard." % full_link)


### PR DESCRIPTION
Escaping `@`s in url is breaking the extension.
I don't have enough experience with complex repo url yet to fix #56 :)

From:
[https://tmosmant%40github.com/ehamiter/GitHubinator/blob/master/githubinator.py#L115](https://tmosmant%40github.com/ehamiter/GitHubinator/blob/master/githubinator.py#L115)
to:
[https://tmosmant@github.com/ehamiter/GitHubinator/blob/master/githubinator.py#L115](https://tmosmant@github.com/ehamiter/GitHubinator/blob/master/githubinator.py#L115)