### PR TITLE
🆕 `force_branch` setting

### DIFF
--- a/Githubinator.sublime-settings
+++ b/Githubinator.sublime-settings
@@ -1,4 +1,5 @@
 {
   "default_remote": "origin",
-  "default_host": "github.com"
+  "default_host": "github.com",
+  "force_branch": false
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ The defaults should work for most setups, but if you have a different remote nam
 
     {
       "default_remote": "origin",
-      "default_host": "github.com"
+      "default_host": "github.com",
+
+      // (optional) override remote branch name; `false` = auto-detect
+      "force_branch": false 
     }
 
 

--- a/githubinator.py
+++ b/githubinator.py
@@ -18,6 +18,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
     """
     DEFAULT_GIT_REMOTE = "origin"
     DEFAULT_HOST = "github.com"
+    FORCE_BRANCH = False
 
     def load_config(self):
         s = sublime.load_settings("Githubinator.sublime-settings")
@@ -27,6 +28,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             self.default_remote = [self.default_remote]
 
         self.default_host = s.get("default_host") or self.DEFAULT_HOST
+        self.force_branch = s.get("force_branch") or self.FORCE_BRANCH
 
     def run(self, edit, copyonly=False, permalink=False, mode="blob", branch=None, open_repo=False):
         self.load_config()
@@ -68,6 +70,9 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
                 self.default_host = matches[4]
 
         re_host = re.escape(self.default_host)
+
+        if self.force_branch:
+          branch = self.force_branch
 
         sha, current_branch = self.get_git_status(git_path)
         if not branch:


### PR DESCRIPTION
If string is provided to `force_branch`,  use it for remote lookups instead of auto-detecting current branch