### PR TITLE
Use configparser to parse the .git/config

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -1,4 +1,5 @@
 import codecs
+import configparser
 import os
 import re
 import sublime
@@ -22,10 +23,6 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
     def load_config(self):
         s = sublime.load_settings("Githubinator.sublime-settings")
         self.default_remote = s.get("default_remote") or self.DEFAULT_GIT_REMOTE
-
-        if not isinstance(self.default_remote, list):
-            self.default_remote = [self.default_remote]
-
         self.default_host = s.get("default_host") or self.DEFAULT_HOST
 
     def run(self, edit, copyonly=False, permalink=False, mode="blob", branch=None, open_repo=False):
@@ -53,21 +50,8 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
         # Read the config file in .git
         git_config_path = os.path.join(git_path, ".git", "config")
-        with codecs.open(git_config_path, "r", "utf-8") as git_config_file:
-            config = git_config_file.read()
-
-        # Figure out the host
-        scheme = "https"
-        result = re.search(r"url.*?=.*?((https?)://([^/]*)/)|(git@([^:]*):)", config)
-        if result:
-            matches = result.groups()
-            if matches[0]:
-                scheme = matches[1]
-                self.default_host = matches[2]
-            else:
-                self.default_host = matches[4]
-
-        re_host = re.escape(self.default_host)
+        config = configparser.ConfigParser(strict=False)
+        config.read(git_config_path)
 
         sha, current_branch = self.get_git_status(git_path)
         if not branch:
@@ -76,51 +60,62 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
         target = sha if permalink else branch
         target = quote_plus(target, safe="/")
 
-        detected_remote = None
-        regex = r".*\s.*(?:remote = )(\w+?)\r?\n"
-        result = re.search(branch + regex, config)
+        branch_section = "branch \"%s\"" % branch
+        if config.has_section(branch_section):
+            remote = config.get(branch_section, "remote") or self.default_remote
+        else:
+            remote = self.default_remote
 
-        if result:
-            matches = result.groups()
-            detected_remote = [matches[0]]
+        remote_section = "remote \"%s\"" % remote
+        url = config.get(remote_section, "url")
 
-        for remote in (detected_remote or self.default_remote):
+        result = re.search(r"((https?)://([^/]*)/)|(git@([^:]*):)", url)
+        if not result:
+            return
 
-            regex = r".*\s.*(?:https?://%s/|%s:|git://%s/)(.*)/(.*?)(?:\.git)?\r?\n" % (re_host, re_host, re_host)
-            result = re.search(remote + regex, config)
-            if not result:
-                continue
+        matches = result.groups()
+        if matches[0]:
+            scheme = matches[1]
+            self.default_host = matches[2]
+        else:
+            scheme = "https"
+            self.default_host = matches[4]
 
-            matches = result.groups()
-            username = matches[0]
-            project = matches[1]
+        re_host = re.escape(self.default_host)
 
-            lines = self.get_selected_line_nums()
+        regex = r"(?:https?://%s/|%s:|git://%s/)(.*)/(.*?)(?:\.git)" % (re_host, re_host, re_host)
+        result = re.search(regex, url)
+        if not result:
+            return
 
-            repo_link = scheme + "://%s/%s/%s/" % (self.default_host, username, project)
+        matches = result.groups()
+        username = matches[0]
+        project = matches[1]
 
-            if open_repo:
-                full_link = repo_link
+        lines = self.get_selected_line_nums()
+
+        repo_link = scheme + "://%s/%s/%s/" % (self.default_host, username, project)
+
+        if open_repo:
+            full_link = repo_link
+        else:
+            if "bitbucket" in self.default_host:
+                mode = "src" if mode == "blob" else "annotate"
+                lines = ":".join([str(l) for l in lines])
+                full_link = repo_link + "%s/%s%s/%s#cl-%s" % \
+                    (mode, sha, new_git_path, file_name, lines)
             else:
-                if "bitbucket" in self.default_host:
-                    mode = "src" if mode == "blob" else "annotate"
-                    lines = ":".join([str(l) for l in lines])
-                    full_link = repo_link + "%s/%s%s/%s#cl-%s" % \
-                        (mode, sha, new_git_path, file_name, lines)
-                else:
-                    lines = "-".join("L%s" % line for line in lines)
-                    full_link = repo_link + "%s/%s%s/%s#%s" % \
-                        (mode, target, new_git_path, file_name, lines)
+                lines = "-".join("L%s" % line for line in lines)
+                full_link = repo_link + "%s/%s%s/%s#%s" % \
+                    (mode, target, new_git_path, file_name, lines)
 
-            full_link = quote(full_link, safe=':/#@')
+        full_link = quote(full_link, safe=':/#@')
 
-            sublime.set_clipboard(full_link)
-            sublime.status_message("Copied %s to clipboard." % full_link)
+        sublime.set_clipboard(full_link)
+        sublime.status_message("Copied %s to clipboard." % full_link)
 
-            if not copyonly:
-                self.view.window().run_command("open_url", {"url": full_link})
-
-            break
+        if not copyonly:
+            self.view.window().run_command("open_url", {"url": full_link})
 
     def get_selected_line_nums(self):
         """Get the line number of selections."""


### PR DESCRIPTION
This allows for a more accurate parsing of the file since we know the
sections, and values within those sections.

Fixes #62 

---

~~I took a crack at using configparser to parse the .git/config file, but I'm leaving this PR as WIP because it actually blows up on some .git/config files I have where there are duplicate sections with the same name (though the duplicate sections are empty).  I'm not sure how to force my .git/config into being like that, so if I figure it out, I'll put it here.  If configparser can't be used, it might be better to just build a simple, custom, parser or find a way around how configparser deals with duplicate but empty sections.~~

The two regexes on lines 72 and 86 can probably be smashed together to make the code simpler, but I didn't want to mess with them in this PR, mostly reusing the original ones.

This is my first time writing Python, so if what I've written is not Pythonic, please let me know and I can fix it up.  Are there tests I should be writing somewhere?  I didn't see any tests, so I wasn't sure.