### PR TITLE
Enable command only for files under git repos

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -232,7 +232,13 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
         return self.recurse_dir(dirname, folder)
 
     def is_enabled(self):
-        if self.view.file_name() and len(self.view.file_name()) > 0:
+        """Enable command only for files under git repos."""
+        full_name = os.path.realpath(self.view.file_name())
+        if not full_name:
+            return False
+
+        git_path = self.recurse_dir(os.path.dirname(full_name), ".git")
+        if git_path:
             return True
         else:
             return False

--- a/githubinator.py
+++ b/githubinator.py
@@ -233,10 +233,10 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
     def is_enabled(self):
         """Enable command only for files under git repos."""
-        full_name = os.path.realpath(self.view.file_name())
-        if not full_name:
+        if not self.view.file_name():
             return False
 
+        full_name = os.path.realpath(self.view.file_name())
         git_path = self.recurse_dir(os.path.dirname(full_name), ".git")
         if git_path:
             return True


### PR DESCRIPTION
For files that are located outside git repos GitHubinator commands are still enabled (both via command palette and right-click context menu). This is likely unnecessary as GitHubinator does not operate on these files.

This pull request proposes to disable GitHubinator commands unless file is under git repo.