### PR TITLE
changed ref lookup to look to active ref before packed ref

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -220,6 +220,8 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
     def get_sha_from_ref(self, git_dir, ref):
         ref_path = os.path.join(git_dir, ref)
+        if not os.path.isfile(ref_path):
+            return None
         with open(ref_path, "r") as f:
             return f.read().strip()
 

--- a/githubinator.py
+++ b/githubinator.py
@@ -158,9 +158,10 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
 
         begin_line = begin[0] + 1
 
-        # If the column index of the end of the selection is 0, that means the user has selected up to and including the EOL character
+        # Unless both regions are the same (meaning nothing is highlighted),
+        # if the column index of the end of the selection is 0, that means the user has selected up to and including the EOL character
         # We don't want to increment `end_line` in that case, because it will highlight the line after the EOL character.
-        end_line = end[0] + 1 if end[1] != 0 else end[0]
+        end_line = end[0] + 1 if (begin == end) or end[1] != 0 else end[0]
 
         if begin_line == end_line:
             lines = [begin_line]

--- a/githubinator.py
+++ b/githubinator.py
@@ -182,9 +182,9 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             # `ref/heads/master`. So we're returning the sha when we return ref.
             return ref, None
 
-        sha = self.get_sha_from_packed_refs(git_dir, ref)
+        sha = self.get_sha_from_ref(git_dir, ref)
         if not sha:
-            sha = self.get_sha_from_ref(git_dir, ref)
+            sha = self.get_sha_from_packed_refs(git_dir, ref)
 
         branch = ref.replace("refs/heads/", "")
 


### PR DESCRIPTION
first time user/contributor here—thanks for creating this plugin!

i was having issues using this plugin in my repo though because it was causing the git shas copied to be outdated/incorrect. i realized this was because the shas stored in `.git/packed-refs` were not actually up-to-date to the active shas for my checked out branches. i'm new to the concept of packed-refs, but in looking at [the git documentation](https://git-scm.com/docs/git-pack-refs), i see this: 

> When a ref is missing from the traditional $GIT_DIR/refs directory hierarchy, it is looked up in this file and used if found.

from that, it seems to use packed-refs as a backup for refs that aren't checked out locally and don't exist in the `refs` folder. as a result, i think the change in this PR is more consistent to how git behaves natively and will fix the issue i've been having with copied refs being incorrect

please let me know if i don't have the right understanding of this though!