### PR TITLE
Making it easier to customize default branch

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -10,9 +10,9 @@
     "args": { "copyonly": true }
   },
   {
-    "caption": "Copy GitHubinator master...",
+    "caption": "Copy GitHubinator default branch...",
     "command": "githubinator",
-    "args": { "copyonly": true, "branch": "master", "permalink": false }
+    "args": { "copyonly": true, "default_branch": true, "permalink": false }
   },
   {
     "caption": "Copy GitHubinator permalink...",
@@ -20,14 +20,14 @@
     "args": { "copyonly": true, "permalink": true }
   },
   {
-    "caption": "Copy GitHubinator master permalink...",
+    "caption": "Copy GitHubinator default branch permalink...",
     "command": "githubinator",
-    "args": { "copyonly": true, "branch": "master", "permalink": true }
+    "args": { "copyonly": true, "default_branch": true, "permalink": true }
   },
   {
-    "caption": "GitHubinator on Master",
+    "caption": "GitHubinator on Default Branch",
     "command": "githubinator",
-    "args": { "permalink": false, "branch": "master" }
+    "args": { "permalink": false, "default_branch": true }
   },
   {
     "caption": "GitHubinator Permalink",
@@ -40,9 +40,9 @@
     "args": { "permalink": false, "mode": "blame" }
   },
   {
-    "caption": "GitHubinator Blame on Master",
+    "caption": "GitHubinator Blame on Default Branch",
     "command": "githubinator",
-    "args": { "permalink": false, "mode": "blame", "branch": "master" }
+    "args": { "permalink": false, "mode": "blame", "default_branch": true }
   },
   {
     "caption": "GitHubinator Blame Permalink",

--- a/Githubinator.sublime-settings
+++ b/Githubinator.sublime-settings
@@ -1,4 +1,5 @@
 {
   "default_remote": "origin",
-  "default_host": "github.com"
+  "default_host": "github.com",
+  "default_branch": "master"
 }

--- a/README.md
+++ b/README.md
@@ -20,36 +20,13 @@ The plugin should be picked up automatically. If not, restart Sublime Text.
 
 ## Configuration
 
-The defaults should work for most setups, but if you have a different remote name or use GitHub Enterprise, you can configure remote and host in the `Githubinator.sublime-settings` file:
+The defaults should work for most setups, but if you have a different remote name, use GitHub Enterprise or default branch, you can configure remote, host, and default branch in the `Githubinator.sublime-settings` file:
 
     {
       "default_remote": "origin",
-      "default_host": "github.com"
+      "default_host": "github.com",
+      "default_branch": "master"
     }
-
-To change the branch name, edit `Default.sublime-commands`.
-
-For example, to change the branch name from `master` to `main`, edit the following as such:
-
-From:
-
-```
-  {
-    "caption": "GitHubinator Blame on Master",
-    "command": "githubinator",
-    "args": { "permalink": false, "mode": "blame", "branch": "master" }
-  },
-```
-
-To:
-
-```
-  {
-    "caption": "GitHubinator Blame on Main",
-    "command": "githubinator",
-    "args": { "permalink": false, "mode": "blame", "branch": "main" }
-  },
-```
 
 ## Usage
 

--- a/githubinator.py
+++ b/githubinator.py
@@ -19,6 +19,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
     """
     DEFAULT_GIT_REMOTE = "origin"
     DEFAULT_HOST = "github.com"
+    DEFAULT_BRANCH = "master"
 
     def load_config(self):
         settings = sublime.load_settings("Githubinator.sublime-settings")
@@ -28,9 +29,11 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             self.default_remote = [self.default_remote]
 
         self.default_host = settings.get("default_host") or self.DEFAULT_HOST
+        self.default_branch = settings.get("default_branch") or self.DEFAULT_BRANCH
 
-    def run(self, edit, copyonly=False, permalink=False, mode="blob", branch=None, open_repo=False):
+    def run(self, edit, copyonly=False, permalink=False, mode="blob", default_branch=False, open_repo=False):
         self.load_config()
+        branch = self.default_branch if default_branch else None
 
         if not self.view.file_name():
             return


### PR DESCRIPTION
I wanted to make a way to more easily customize the name of the default branch, so that's what this is. This way you don't have to overwrite all of the commands, it's just one simple setting. It can be changed to `main`, `develop`, or whatever.