### PR TITLE
Fix "Open on Master" menu item

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -3,13 +3,13 @@
         "caption": "GitHubinator",
         "children": [
             { "caption": "Open", "command": "githubinator", "args": { "permalink": false } },
-            { "caption": "Open on Master", "command": "githubinator", "args": { "permalink": false, "default_branch": true } },
+            { "caption": "Open on default branch", "command": "githubinator", "args": { "permalink": false, "default_branch": true } },
             { "caption": "Open permalink", "command": "githubinator", "args": { "permalink": true } },
             { "caption": "Copy link", "command": "githubinator", "args": { "permalink": false, "copyonly": true } },
-            { "caption": "Copy link on Master", "command": "githubinator", "args": { "permalink": false, "copyonly": true, "default_branch": true } },
+            { "caption": "Copy link on default branch", "command": "githubinator", "args": { "permalink": false, "copyonly": true, "default_branch": true } },
             { "caption": "Copy permalink", "command": "githubinator", "args": { "permalink": true, "copyonly": true } },
             { "caption": "Open blame", "command": "githubinator", "args": { "permalink": false, "mode": "blame" } },
-            { "caption": "Open blame on Master", "command": "githubinator", "args": { "permalink": false, "mode": "blame", "default_branch": true } },
+            { "caption": "Open blame on default branch", "command": "githubinator", "args": { "permalink": false, "mode": "blame", "default_branch": true } },
             { "caption": "Open blame permalink", "command": "githubinator", "args": { "permalink": true, "mode": "blame" } },
             { "caption": "Open repository", "command": "githubinator", "args": { "permalink": false, "open_repo": true } }
         ]

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -3,13 +3,13 @@
         "caption": "GitHubinator",
         "children": [
             { "caption": "Open", "command": "githubinator", "args": { "permalink": false } },
-            { "caption": "Open on Master", "command": "githubinator", "args": { "permalink": false, "branch": "master" } },
+            { "caption": "Open on Master", "command": "githubinator", "args": { "permalink": false, "default_branch": true } },
             { "caption": "Open permalink", "command": "githubinator", "args": { "permalink": true } },
             { "caption": "Copy link", "command": "githubinator", "args": { "permalink": false, "copyonly": true } },
-            { "caption": "Copy link on Master", "command": "githubinator", "args": { "permalink": false, "copyonly": true, "branch": "master" } },
+            { "caption": "Copy link on Master", "command": "githubinator", "args": { "permalink": false, "copyonly": true, "default_branch": true } },
             { "caption": "Copy permalink", "command": "githubinator", "args": { "permalink": true, "copyonly": true } },
             { "caption": "Open blame", "command": "githubinator", "args": { "permalink": false, "mode": "blame" } },
-            { "caption": "Open blame on Master", "command": "githubinator", "args": { "permalink": false, "mode": "blame", "branch": "master" } },
+            { "caption": "Open blame on Master", "command": "githubinator", "args": { "permalink": false, "mode": "blame", "default_branch": true } },
             { "caption": "Open blame permalink", "command": "githubinator", "args": { "permalink": true, "mode": "blame" } },
             { "caption": "Open repository", "command": "githubinator", "args": { "permalink": false, "open_repo": true } }
         ]


### PR DESCRIPTION
https://github.com/ehamiter/GitHubinator/pull/80 made it easier to change the default branch (nice!), but forgot to update the context menu, breaking "Open on Master" and other menu items. This PR fixes the functionality of the menu items.

This PR _doesn't_ change the "Open on Master" menu text, because I couldn't see an easy way to change it based on the config? That option text might be confusing if you've configured your `default_branch` to be something other than "master". We could change it to "Open on main" or "Open on trunk" or some other generic option? (Or just leave it as-is, it's not _that_ confusing.)