### PR TITLE
use webbrowser.open_new_tab

### DIFF
--- a/githubinator.py
+++ b/githubinator.py
@@ -1,6 +1,7 @@
 import codecs
 import os
 import re
+import webbrowser
 
 import sublime
 import sublime_plugin
@@ -149,7 +150,7 @@ class GithubinatorCommand(sublime_plugin.TextCommand):
             sublime.status_message("Copied %s to clipboard." % full_link)
 
             if not copyonly:
-                self.view.window().run_command("open_url", {"url": full_link})
+                webbrowser.open_new_tab(full_link)
 
             break
 


### PR DESCRIPTION
Did not investigate much but this did not work with my sublime4:
`window.run_command("open_url", {"url": "http://www.sublimetext.com/docs/3/api_reference.html"})`
gives:
`TypeError: run() got an unexpected keyword argument 'url'`

So use `webbrowser.open_new_tab` instead.

Tested with Sublime 3 and 4.